### PR TITLE
Add --std=gnu99 arg to gcc calls

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,10 @@ AC_PROG_MKDIR_P
 
 AX_CXX_COMPILE_STDCXX_11(noext,mandatory)
 
+AC_PROG_CC_STDC
+# Added for automake 1.13 on CentOS 7, obsolecent starting with automake 1.14
+AM_PROG_CC_C_O
+
 # std::thread requires pthread
 AX_PTHREAD( [
             AC_DEFINE(HAVE_PTHREAD,1,[Define if you have POSIX threads libraries and header files.])


### PR DESCRIPTION
On CentOS 7.2, gcc seems to need some gentle encouragment to compile episnoop with autotools.

I was experiencing the following issues and found that adding `--std=gnu99` through autoconf makes it compile again.

```
  CC       src/firecode.o
src/firecode.c: In function 'firecode_crc':
src/firecode.c:34:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (size_t len = 0; len < size; len++) {
     ^
src/firecode.c:34:5: note: use option -std=c99 or -std=gnu99 to compile your code
src/firecode.c:35:9: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0x80; i != 0; i >>= 1) {
         ^
make[1]: *** [src/firecode.o] Error 1
make[1]: Leaving directory `/root/rpmbuild/BUILD/etisnoop-1.1.0'
```

FWIW, this is the bundled GCCs version on CentOS.

```
$ gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-4)
```
