### PR TITLE
Fix codepage conversion for shortlabel

### DIFF
--- a/src/ensembledatabase.cpp
+++ b/src/ensembledatabase.cpp
@@ -82,7 +82,22 @@ std::string label_t::shortlabel() const
         }
     }
 
-    return shortlabel;
+    switch (charset) {
+        case charset_e::COMPLETE_EBU_LATIN:
+            return convert_ebu_to_utf8( shortlabel );
+        case charset_e::UTF8:
+            return shortlabel;
+        case charset_e::UCS2:
+            try {
+                return ucs2toutf8((uint8_t*)shortlabel.c_str(), shortlabel.length());
+            }
+            catch (const range_error&) {
+                return "";
+            }
+        case charset_e::UNDEFINED:
+            throw logic_error("charset undefined");
+    }
+    throw logic_error("invalid charset " + to_string((int)charset));
 }
 
 string label_t::assemble() const


### PR DESCRIPTION
During testing I've found out that special characters of the slovenian alphabet are not correclty decoded in the shortlabel.
As the label was correctly decoded, a comparison showed that the codepage conversion was missing. Now it works. At least for EBU_Latin codepage (which we use)