### PR TITLE
Fix carousel fig statistic output

### DIFF
--- a/src/repetitionrate.cpp
+++ b/src/repetitionrate.cpp
@@ -171,7 +171,7 @@ void rate_display_analysis(bool per_second)
                 printf(" - %6.2f (%5zu)", avg, n_complete);
             }
             else {
-                printf(" - None complete");
+                printf(" - None complete ");
             }
         }
         else {


### PR DESCRIPTION
there was a missing space at the end

# before

```
CAROUSEL FIG 0/ 0   4.00 (  164) -   4.00 (  164) -  5.0 [▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0
CAROUSEL FIG 0/ 1   1.34 (  487) -   4.03 (  162) - 22.3 [▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇] -  0 1 2
CAROUSEL FIG 0/ 2   1.01 (  651) -   4.03 (  162) - 21.0 [▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁] -  0 1 2
CAROUSEL FIG 0/ 6 140.67 (    4) - 212.00 (    2) - 11.0 [▁▁▁▁▁▁▁▅▁▁▃▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁] -  0 2
CAROUSEL FIG 0/ 8   2.58 (  251) -  42.00 (   15) -  5.0 [▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 0/ 9  42.00 (   16) -  42.00 (   16) -  4.0 [▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 0/10  42.00 (   16) -  42.00 (   16) -  7.0 [▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 0/13  10.50 (   61) -  42.00 (   15) - 29.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇] -  0 1 2
CAROUSEL FIG 0/17  10.21 (   63) -  42.00 (   15) - 17.2 [▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇] -  0 1 2
CAROUSEL FIG 0/21 420.00 (    2) - None complete -  8.5 [▁▁▁▁▁▁▁▁▄▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0
CAROUSEL FIG 0/24 314.50 (    3) - None complete - 18.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▄▁▁▁▁▁▁▁▄▁▁▁▁▁] -  0 2
CAROUSEL FIG 1/ 0  41.93 (   16) -  41.93 (   16) - 21.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 1/ 1   2.59 (  250) -  42.00 (   15) - 21.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁] -  0 1 2
```

# after

```
CAROUSEL FIG 0/ 0   4.00 (  164) -   4.00 (  164) -  5.0 [▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0
CAROUSEL FIG 0/ 1   1.34 (  487) -   4.03 (  162) - 22.3 [▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇] -  0 1 2
CAROUSEL FIG 0/ 2   1.01 (  651) -   4.03 (  162) - 21.0 [▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁] -  0 1 2
CAROUSEL FIG 0/ 6 140.67 (    4) - 212.00 (    2) - 11.0 [▁▁▁▁▁▁▁▅▁▁▃▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁] -  0 2
CAROUSEL FIG 0/ 8   2.58 (  251) -  42.00 (   15) -  5.0 [▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 0/ 9  42.00 (   16) -  42.00 (   16) -  4.0 [▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 0/10  42.00 (   16) -  42.00 (   16) -  7.0 [▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 0/13  10.50 (   61) -  42.00 (   15) - 29.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇] -  0 1 2
CAROUSEL FIG 0/17  10.21 (   63) -  42.00 (   15) - 17.2 [▁▁▁▁▁▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇] -  0 1 2
CAROUSEL FIG 0/21 420.00 (    2) - None complete  -  8.5 [▁▁▁▁▁▁▁▁▄▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁] -  0
CAROUSEL FIG 0/24 314.50 (    3) - None complete  - 18.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▁▄▁▁▁▁▁▁▁▄▁▁▁▁▁] -  0 2
CAROUSEL FIG 1/ 0  41.93 (   16) -  41.93 (   16) - 21.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁] -  0 1 2
CAROUSEL FIG 1/ 1   2.59 (  250) -  42.00 (   15) - 21.0 [▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▁▁▁▁▁▁▁] -  0 1 2
```